### PR TITLE
fix: Deployment docker cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
 
       # 3. Set up Buildx (Docker advanced builder), basically docker build knows how to
       # pull cache (cache-from), but it needs Buildx pack it and send back to Github.
+      # cache-to defines when docker build is done, store those layers to the 'cloud'
+      # - Githubs box - for future runs to use. Github runners don't have memory between runs,
+      # so this is the only way to cache docker layers between workflow runs.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,12 @@ jobs:
           # GitHub automatically creates this secret on every run to allow actions to interact with the repo
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 3. Dynamic Metadata (Tagging) - prepare names (tags) this image will be pushed with.
+      # 3. Set up Buildx (Docker advanced builder), basically docker build knows how to
+      # pull cache (cache-from), but it needs Buildx pack it and send back to Github.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # 4. Dynamic Metadata (Tagging) - prepare names (tags) this image will be pushed with.
       # This step also generetes OCI (Open Container Initiative) labels (metadata) for the image
       # and these include things like: repo, actor, commit, time, etc.
       - name: Extract metadata
@@ -77,7 +82,7 @@ jobs:
             # especially for the case of rollbacks - latest will always be only the newest,
             # and for rollback we need sha tags of the previous deployments)
 
-      # 4. Build & Push (Dockerfile)
+      # 5. Build & Push (Dockerfile)
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -88,7 +93,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 5. SSH Deploy (Dynamic Logic)
+      # 6. SSH Deploy (Dynamic Logic)
       - name: Deploy to Server via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:


### PR DESCRIPTION
In this PR I've:

1. Fixed the deployment error `ERROR: failed to build: Cache export is not supported for the docker driver.` by adding BuildX action