### PR TITLE
fix: Remove PGAdmin env vars from prod

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,30 @@
+# --- APPLICATION CONFIG ---
+NODE_ENV=development
+APP_NAME=taskie-api
+APP_PORT=8000
+API_PREFIX=api
+
+# --- DATABASE CONFIG ---
+DATABASE_TYPE=postgres
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_USERNAME=taskie
+DATABASE_PASSWORD=taskie
+DATABASE_NAME=taskie_db
+DATABASE_POOL_SIZE=10
+
+# --- PGADMIN CONFIG (Used by Docker Compose only on local development) ---
+# Note: These are not used by the NestJS app directly
+DATABASE_PGADMIN_EMAIL=admin@example.com
+DATABASE_PGADMIN_PASSWORD=admin_pass
+
+# --- AUTH & JWT ---
+AUTH_JWT_SECRET=replace_this_secret_in_prod
+AUTH_JWT_TOKEN_EXPIRES_IN=900000 # 15 minutes
+
+AUTH_REFRESH_SECRET=replace_this_refresh_secret_in_prod
+AUTH_REFRESH_TOKEN_EXPIRES_IN=86400000 # 1 day
+
+# --- GOOGLE AUTH ---
+AUTH_GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
+AUTH_GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/api/src/database/config/database.config.ts
+++ b/api/src/database/config/database.config.ts
@@ -1,11 +1,11 @@
 import { registerAs } from '@nestjs/config';
 import {
   IsInt,
-  Min,
-  Max,
-  IsString,
-  IsNumber,
   IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  Min,
 } from 'class-validator';
 import validateConfig from '../../common/helper/validate-config';
 import { DatabaseConfig } from './database-config.type';
@@ -41,14 +41,6 @@ class DatabaseEnvironmentVariablesValidator {
   @IsNumber()
   DATABASE_POOL_SIZE: number;
 
-  @IsNotEmpty()
-  @IsString()
-  DATABASE_PGADMIN_EMAIL: string;
-
-  @IsNotEmpty()
-  @IsString()
-  DATABASE_PGADMIN_PASSWORD: string;
-
   constructor(
     DATABASE_TYPE: string,
     DATABASE_HOST: string,
@@ -57,8 +49,6 @@ class DatabaseEnvironmentVariablesValidator {
     DATABASE_USERNAME: string,
     DATABASE_PASSWORD: string,
     DATABASE_POOL_SIZE: number,
-    DATABASE_PGADMIN_EMAIL: string,
-    DATABASE_PGADMIN_PASSWORD: string,
   ) {
     this.DATABASE_TYPE = DATABASE_TYPE;
     this.DATABASE_HOST = DATABASE_HOST;
@@ -67,8 +57,6 @@ class DatabaseEnvironmentVariablesValidator {
     this.DATABASE_USERNAME = DATABASE_USERNAME;
     this.DATABASE_PASSWORD = DATABASE_PASSWORD;
     this.DATABASE_POOL_SIZE = DATABASE_POOL_SIZE;
-    this.DATABASE_PGADMIN_EMAIL = DATABASE_PGADMIN_EMAIL;
-    this.DATABASE_PGADMIN_PASSWORD = DATABASE_PGADMIN_PASSWORD;
   }
 }
 


### PR DESCRIPTION
In this PR I've:

1. Removed env validation for PGAdmin credentials, and added .env.example instead