### PR TITLE
fix: Static and API routing

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -50,6 +50,7 @@ import { WorkspaceModule } from './modules/workspace/workspace-module/workspace.
     AppLoggerModule,
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'public'),
+      exclude: ['/api/(.*)'],
     }),
   ],
   providers: [


### PR DESCRIPTION
In this PR I've:

1. Excluded `api` subroute from NestJS static module, for the purpose of Nginx api.taskieapp.xyz and taskieapp.xyz routing