### PR TITLE
feat: Update .github workflows

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -13,41 +13,7 @@ on:
       - "api/**"
 
 jobs:
-  # JOB 1: Check PR title (Conventional Commits)
-  # Since we use squash merging, checking commit messages is not effective (commitlint)
-  check-pr-title:
-    name: Validate PR Title
-    runs-on: ubuntu-latest
-    # Vrti se samo na PR-ovima, ne na pushu u main
-    if: github.event_name == 'pull_request'
-    steps:
-      # PR to develop - check commit message
-      - name: Verify Conventional Commits
-        if: github.base_ref != 'main'
-        uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Allows types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-          validateSingleCommit: false
-
-      # PR to main - strict title check ("Develop to main")
-      - name: Verify Release Title
-        if: github.base_ref == 'main'
-        run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          EXPECTED="Develop to main"
-
-          if [ "$TITLE" != "$EXPECTED" ]; then
-            echo "❌ ERROR: Merging to 'main' requires strict title."
-            echo "Expected: '$EXPECTED'"
-            echo "Received: '$TITLE'"
-            exit 1
-          else
-            echo "✅ Title is valid for release."
-          fi
-
-  # JOB 2: Check code quality
+  # JOB 1: Check code quality
   quality-check:
     name: Lint, Test & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,16 +1,9 @@
-name: API CI Pipeline
+name: PR Lint and Validation
 
 on:
   # On every pull request
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    paths:
-      - "api/**"
-  # On push to main (this should generally happen via PRs develop to main)
-  push:
-    branches: [main]
-    paths:
-      - "api/**"
 
 jobs:
   # JOB 1: Check PR title (Conventional Commits)
@@ -18,8 +11,6 @@ jobs:
   check-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    # Vrti se samo na PR-ovima, ne na pushu u main
-    if: github.event_name == 'pull_request'
     steps:
       # PR to develop - check commit message
       - name: Verify Conventional Commits
@@ -46,34 +37,3 @@ jobs:
           else
             echo "✅ Title is valid for release."
           fi
-
-  # JOB 2: Check code quality
-  quality-check:
-    name: Lint, Test & Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./api
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm" # Cache node_modules
-          cache-dependency-path: api/package-lock.json # Specify path to lockfile
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check Linting
-        # Only check if there are linting errors, do not auto-fix
-        run: npm run lint:check
-
-      - name: Run Tests
-        run: npm run test
-
-      - name: Build Project
-        run: npm run build


### PR DESCRIPTION
In this PR I've:

1. Updated `api-deploy` workflow: this workflow triggerable only when /api dir is edited
3. Added `lint-pt` workflow: took PR title check logic from the `api-deploy` workflow and made it into this new workflow as it didn't make sense to have there