### PR TITLE
fix: Wrong DB migration run command

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -58,4 +58,4 @@ USER node
 # from the api-deploy workflow SSH bash script.
 # Using 'exec' before 'node dist/main.js' replaces the shell with the node process,
 # ensuring proper signal handling (e.g., for graceful shutdowns).
-CMD ["sh", "-c", "npm run migration:prod && exec node dist/main.js"]
+CMD ["sh", "-c", "npm run db:migration:run:prod && exec node dist/main.js"]


### PR DESCRIPTION
In this PR I've:

1. Fixed the wrong DB migration script used in the Dockerfile