### PR TITLE
fix: DB trigger .sql file not included in dist

### DIFF
--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -4,12 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "assets": [
-      {
-        "include": "../public/**/*",
-        "outDir": "dist/public",
-        "watchAssets": true
-      }
-    ]
+    "assets": ["**/*.sql"]
   }
 }


### PR DESCRIPTION
In this PR I've:

1. Fixed missing DB trigger .sql file missing in built dist folder - the reason is `node build` includes only `.ts` files, so I had to amend `nest-cli.json`
2. Also removed `public` from `nest-cli.json` as we are not serving public files from NestJS anymore